### PR TITLE
Extend dashboard and calculation functionality

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120
       - name: Upload Failure screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots

--- a/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
+++ b/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
@@ -211,8 +211,7 @@ const OutputVisualizerPage = ({projectName, getData, toasting }) => {
                                 }>Add Executed Event Log</Button>
                                 <Spacer/>
                                 <Box>
-                                    <Text fontSize="s" textAlign="start" color="#485152" fontWeight="bold" > Select calculation mode:</Text>
-                                    <Select value={calculationMode} placeholder = 'choose calculation'
+                                    <Select value={calculationMode} placeholder = 'Calculation mode'
                                         width = '100%'  {...(!calculationMode && {color: "gray"})} 
                                         backgroundColor= 'white' icon={<FiChevronDown />}
                                         onChange={evt => {setCalculationMode(evt.target.value); reload();}}>

--- a/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
+++ b/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
@@ -1,6 +1,6 @@
 import { Box, Button, Card, CardBody, CardHeader, Flex, Heading, Spacer, Stack } from "@chakra-ui/react";
 import Multibarchart from "./Multibarchart";
-import { deleteFile, getFile, getFiles } from "../../util/Storage";
+import { deleteFile, getFile, getFiles, uploadFileToProject } from "../../util/Storage";
 import { useEffect, useState } from "react";
 import TabBar from "../TabBar.jsx";
 import { axisClasses } from "@mui/x-charts";
@@ -44,13 +44,16 @@ const OutputVisualizerPage = ({projectName, getData, toasting }) => {
                 const folderName = fileData.path.split('/').slice(3, -1).join('/');
                 const resourceUtilsFile = fileList.filter(fileName => fileName.startsWith(folderName) && fileName.endsWith('resourceutilization.xml'))[0];
                 let scenarioLabel;
+                let scenarioKey;
                 try {
                     scenarioLabel = resourceUtilsFile.split('/').slice(-1)[0].split('_Global_resourceutilization.xml')[0];
+                    scenarioKey = 'scenario_' + folderName;
                 } catch (error) {
-                    scenarioLabel = "Uploaded"
+                    scenarioLabel = "Uploaded";
+                    scenarioKey = 'uploaded';
                 }
-
-                const scenarioKey = 'scenario_' + folderName;
+                
+                
                 totalChartDataToBe.series.push({ dataKey: scenarioKey, label: scenarioLabel, valueFormatter });
                 activityChartDataToBe.series.push({ dataKey: scenarioKey, label: scenarioLabel, valueFormatter });
 
@@ -152,6 +155,13 @@ const OutputVisualizerPage = ({projectName, getData, toasting }) => {
                                 <Spacer/>
                             </Flex>
                         </CardHeader>
+                         <CardBody>
+                            You can add additional event logs to compare simulated cost with executed costs
+                            <Button variant='link' onClick={async () => {
+                                await uploadFileToProject(projectName);
+                            }
+                            }>here</Button>.
+                            </CardBody>
                         <CardBody>
                             {activityChartData && totalChartData && <TabBar
                                 setCurrent={() => {reload()}}

--- a/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
+++ b/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
@@ -214,10 +214,9 @@ const OutputVisualizerPage = ({projectName, getData, toasting }) => {
                                 <Box>
                                     <FormControl>
                                         <Select value={calculationMode}
-                                            width = '100%'  {...(!calculationMode && {color: "gray"})} 
+                                            width = '100%'  {...(!calculationMode && {color: "gray"})} defaultValue={'AVERAGE'}
                                             backgroundColor= 'white' icon={<FiChevronDown />}
                                             onChange={evt => {setCalculationMode(evt.target.value); reload();}}>
-                                            <option value='' disabled={true} hidden={true}>Calculation Mode</option>
                                             <option value='AVERAGE' color="black">Average</option>
                                             <option value='MEDIAN' color="black">Median</option>
                                             <option value='MIN' color="black">Min</option>

--- a/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
+++ b/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
@@ -1,4 +1,4 @@
-import { Box, Button, Card, CardBody, CardHeader, Flex, Heading, Spacer, Select, Stack, Text } from "@chakra-ui/react";
+import { Box, Button, Card, CardBody, CardHeader, Flex, FormControl, FormLabel, Heading, Spacer, Select, Stack, Text } from "@chakra-ui/react";
 import Multibarchart from "./Multibarchart";
 import { deleteFile, getFile, getFiles, uploadFileToProject, uploadFile, setFile } from "../../util/Storage";
 import { useEffect, useState } from "react";
@@ -212,15 +212,19 @@ const OutputVisualizerPage = ({projectName, getData, toasting }) => {
                                 }>Add Executed Event Log</Button>
                                 <Spacer/>
                                 <Box>
-                                    <Select value={calculationMode} placeholder = 'Calculation mode'
-                                        width = '100%'  {...(!calculationMode && {color: "gray"})} 
-                                        backgroundColor= 'white' icon={<FiChevronDown />}
-                                        onChange={evt => {setCalculationMode(evt.target.value); reload();}}>
-                                        <option value='AVERAGE' color="black">Average</option>
-                                        <option value='MEDIAN' color="black">Median</option>
-                                        <option value='MIN' color="black">Min</option>
-                                        <option value='MAX' color="black">Max</option>
-                                    </Select>
+                                    <FormControl>
+                                        <Select value={calculationMode}
+                                            width = '100%'  {...(!calculationMode && {color: "gray"})} 
+                                            backgroundColor= 'white' icon={<FiChevronDown />}
+                                            onChange={evt => {setCalculationMode(evt.target.value); reload();}}>
+                                            <option value='' disabled={true} hidden={true}>Calculation Mode</option>
+                                            <option value='AVERAGE' color="black">Average</option>
+                                            <option value='MEDIAN' color="black">Median</option>
+                                            <option value='MIN' color="black">Min</option>
+                                            <option value='MAX' color="black">Max</option>
+                                        </Select>
+                                        <FormLabel>Calculation Mode</FormLabel>
+                                    </FormControl>
                                 </Box>
                                 <Spacer/>
                             </Flex>

--- a/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
+++ b/frontend/src/components/OutputVisualizer/OutputVisualizer.jsx
@@ -102,10 +102,11 @@ const OutputVisualizerPage = ({projectName, getData, toasting }) => {
                 for (const trace of [...fileXml.getElementsByTagName('trace')]) {
                     // get all events
                     for (const event of trace.getElementsByTagName('event')) {
+                        const lifecycleTransition = event.querySelector('[key="lifecycle:transition"]').getAttribute("value");
                         const activityName = event.querySelector('[key="concept:name"]').getAttribute("value");
                         const storedEventCost = event.querySelector('[key="cost:activity"]')
-                        // check if event has cost attached to it
-                        if (storedEventCost != null) {
+                        // check if event has cost attached to it and is an end activity
+                        if (storedEventCost != null && lifecycleTransition == "complete") {
                             const activityCost = storedEventCost.getAttribute("value");
 
                             let allCostsOfActivity = activityCostMap.get(activityName)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "simulation-bridge",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "simulation-bridge",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "license": "ISC",
             "workspaces": [
                 "frontend",


### PR DESCRIPTION
This PR

- Changes the calculation of environmental impacts for the dashboard to be done on event logs themselves instead of the statistics.xml
- Implements a rudimentary upload functionality so that event logs extracted from runtime (e.g. from Camunda) can be compared against simulation scenarios
- Allows to toggle the impact calculation between median, mean, max, and min
- Makes sure that the calculation is being done only based on _complete_ events, regardless of whether the uploaded event log adheres to this convention